### PR TITLE
test: migrate to pytest-jubilant 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
   "tenacity==9.0.0",  # can't upgrade without bumping the python version too.
   "requests==2.32.4",
   "jubilant",
-  "pytest-jubilant>=0.4.1",
+  "pytest-jubilant>=2,<3",
 ]
 
 # Testing tools configuration

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,7 +6,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-from pytest_jubilant import pack_charm
 
 logger = logging.getLogger(__name__)
 
@@ -21,10 +20,36 @@ def scrape_target_charm() -> Path:
     for _ in range(3):
         logger.info("packing...")
         try:
-            pth = pack_charm().charm.absolute()
+            pth = pack()
         except subprocess.CalledProcessError:
             logger.warning("Failed to build the charm. Trying again!")
             continue
         os.environ["CHARM_PATH"] = str(pth)
         return pth
     raise err  # noqa
+
+
+def pack(root: Path | str = "./", platform: str | None = None) -> Path:
+    """Pack a local charm and return it."""
+    cmd = ["charmcraft", "pack", "--project-dir", root]
+    if platform:
+        cmd.extend(["--platform", platform])
+    proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    # stderr looks like:
+    # > charmcraft pack
+    # Packed tempo-coordinator-k8s_ubuntu@24.04-amd64.charm
+    # Packed tempo-coordinator-k8s_ubuntu@22.04-amd64.charm
+    packed_charms = [
+        line.split()[1] for line in proc.stderr.strip().splitlines() if line.startswith("Packed")
+    ]
+    if not packed_charms:
+        raise ValueError(
+            "Unable to get packed charm(s)!"
+            f" ({cmd!r} completed with {proc.returncode=}, {proc.stdout=}, {proc.stderr=})"
+        )
+    if len(packed_charms) > 1:
+        raise ValueError(
+            "This charm supports multiple platforms. "
+            "Pass a `platform` argument to control which charm you're getting instead."
+        )
+    return Path(packed_charms[0]).resolve()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -61,7 +61,7 @@ def test_profiling_is_configured(juju: Juju):
     assert PARCA_TARGET in response.text
 
 
-@mark.teardown
+@mark.juju_teardown
 def test_teardown(juju: Juju):
     juju.remove_application(PARCA)
     juju.remove_application(PARCA_TARGET)

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -26,7 +26,7 @@ def get_unit_ip(juju: Juju, app_name, unit_id):
 
 
 @mark.abort_on_fail
-@mark.setup
+@mark.juju_setup
 def test_deploy(juju: Juju, scrape_target_charm):
     # GIVEN an empty model
 
@@ -86,6 +86,6 @@ def test_profiling_is_configured(juju: Juju):
     assert PARCA_TARGET in response.text
 
 
-@mark.teardown
+@mark.juju_teardown
 def test_remove_parca_target(juju: Juju):
     juju.remove_application(PARCA_TARGET)

--- a/uv.lock
+++ b/uv.lock
@@ -432,7 +432,7 @@ requires-dist = [
     { name = "ops", extras = ["testing"], marker = "extra == 'dev'" },
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==8.3.5" },
-    { name = "pytest-jubilant", marker = "extra == 'dev'", specifier = ">=0.4.1" },
+    { name = "pytest-jubilant", marker = "extra == 'dev'", specifier = ">=2,<3" },
     { name = "requests", marker = "extra == 'dev'", specifier = "==2.32.4" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.12.9" },
     { name = "tenacity", marker = "extra == 'dev'", specifier = "==9.0.0" },
@@ -697,15 +697,15 @@ wheels = [
 
 [[package]]
 name = "pytest-jubilant"
-version = "1.3.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jubilant" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/31/2726f3a38c94036434e5744fd727e517495814692aa79f5200444dd5d18a/pytest_jubilant-1.3.0.tar.gz", hash = "sha256:93e05233172e33a76f96e162fd9aeb5161f453abd7de521183631857bb77a8ea", size = 12752, upload-time = "2026-03-13T02:04:14.435Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/b6/d98999f1d0a0c9313154fe7bf8f4e3639729b7052c736f2f12cd7025201c/pytest_jubilant-2.0.0.tar.gz", hash = "sha256:c5f8382ac0b43bca8ef87e309f587e2fc1751ff7b2677dd28a66989b6605e063", size = 16250, upload-time = "2026-03-29T23:39:57.966Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/85/07093962c95599bc27ee35734951466fcb367f2ce24f8a9cac6f297a789a/pytest_jubilant-1.3.0-py3-none-any.whl", hash = "sha256:520c04f5a4a5d1d9e3729424d4f8bd6b01153c0284fb3e2fda8fe90fae79cc4a", size = 11831, upload-time = "2026-03-13T02:04:13.131Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c3/234c3ec22b230e7e33732f91d19d72ad84101a97353b03be3450e4188c5c/pytest_jubilant-2.0.0-py3-none-any.whl", hash = "sha256:28fcf3750100eda16658c2967af099a39199af9fd102ab3b5ba230a028efec3e", size = 13354, upload-time = "2026-03-29T23:39:56.66Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

The `pytest-jubilant` [2.0 release](https://github.com/canonical/pytest-jubilant/releases/tag/v2.0.0) breaks this repo's tests.

## Solution
<!-- A summary of the solution addressing the above issue -->

This PR migrates the tests to use the 2.0 API. This includes defining copies of the `pack` and `get_resources` helpers dropped from `pytest-jubilant`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Charm Tech will maintain the `pytest-jubilant` 2.0 API going forward. We dropped `pack` and `get_resources` to scope the library more tightly to `pytest` + `jubilant`. In general, we think it's cleaner to avoid calling `charmcraft pack` inside your Python integration test suite.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Integration tests should pass.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A.